### PR TITLE
testnet has different keystore location

### DIFF
--- a/contents/runninganode.rst
+++ b/contents/runninganode.rst
@@ -164,6 +164,12 @@ The ``swarm`` daemon will seek out and connect to other swarm nodes. It manages 
 Using swarm together with the Ropsten testnet blockchain
 --------------------------------------------------------
 
+In case you don't yet have an account, run
+
+.. code-block:: none
+
+  geth --datadir $DATADIR --testnet account new
+
 Run a geth node connected to the Ropsten testnet
 
 .. code-block:: none
@@ -181,6 +187,7 @@ Then launch the swarm; connecting it to the geth node (--ethapi).
 
   swarm --bzzaccount $BZZKEY \
          --datadir $DATADIR \
+         --keystore $DATADIR/testnet/keystore \
          --ethapi $DATADIR/geth.ipc \
          2>> $DATADIR/swarm.log < <(echo -n "MYPASSWORD") &
 


### PR DESCRIPTION
When running geth with "--testnet" param, the keystore location is $DATADIR/testnet/keystore.
swarm expects a keystore in $DATADIR/keystore.
I added the (optional) command for creating a testnet account and the "--keystore" param to the swarm command.