### PR TITLE
Add a full path for geth command in runninganode

### DIFF
--- a/contents/runninganode.rst
+++ b/contents/runninganode.rst
@@ -12,6 +12,8 @@ To start a basic swarm node we must start geth with an empty data directory on a
 
 First set aside an empty temporary directory to be the data store
 
+..  note:: If you followed the installation instructions from this guide, you will find your executables in the $GOPATH/bin directory. Make sure to move your files into an executable $PATH, or include $GOPATH/bin directory on it.
+
 .. code-block:: none
 
    DATADIR=/tmp/BZZ/`date +%s`
@@ -20,7 +22,7 @@ then make a new account using this directory
 
 .. code-block:: none
 
-  $GOPATH/bin/geth --datadir $DATADIR account new
+  geth --datadir $DATADIR account new
 
 You will be prompted for a password:
 
@@ -51,7 +53,7 @@ With the preparations complete, we can now launch our swarm client. To launch in
 
 .. code-block:: none
 
-  nohup $GOPATH/bin/geth --datadir $DATADIR \
+  nohup geth --datadir $DATADIR \
          --unlock 0 \
          --password <(echo -n "MYPASSWORD") \
          --verbosity 6 \

--- a/contents/runninganode.rst
+++ b/contents/runninganode.rst
@@ -20,7 +20,7 @@ then make a new account using this directory
 
 .. code-block:: none
 
-  geth --datadir $DATADIR account new
+  $GOPATH/bin/geth --datadir $DATADIR account new
 
 You will be prompted for a password:
 
@@ -51,7 +51,7 @@ With the preparations complete, we can now launch our swarm client. To launch in
 
 .. code-block:: none
 
-  nohup geth --datadir $DATADIR \
+  nohup $GOPATH/bin/geth --datadir $DATADIR \
          --unlock 0 \
          --password <(echo -n "MYPASSWORD") \
          --verbosity 6 \


### PR DESCRIPTION
If we said that `geth` is made with `go install`, we should stick with it for the rest of the guide. As some people does not have `$GOPATH/bin` in the `PATH` environment variable.