### PR TITLE
Fix swarm command

### DIFF
--- a/contents/runninganode.rst
+++ b/contents/runninganode.rst
@@ -64,13 +64,13 @@ and launch the swarm; connecting it to the geth node. For consistency, let's use
 
 .. code-block:: none
 
-  swarm --bzzaccount $BZZKEY \
+  $GOPATH/bin/swarm --bzzaccount $BZZKEY \
          --datadir $DATADIR \
          --ethapi $DATADIR/geth.ipc \
          --verbosity 6 \
          --maxpeers 0 \
-         --networkid 322 \
-         2>> $DATADIR/swarm.log < <(echo -n "MYPASSWORD") &
+         --bzznetworkid 322 \
+         &> $DATADIR/swarm.log < <(echo -n "MYPASSWORD") &
 
 .. note:: In this example, running geth is optional, it is not strictly needed. To run without geth, simply remove the --ethapi flag from swarm.
 


### PR DESCRIPTION
Fix `swarm` to be `$GOPATH/bin/swarm`, as we are using `go install` and we can find users that don't have `$GOPATH/bin` in the path, leading to an error (see #24 where a similar situation is experienced with `geth`).

Also, fix `--bzznetwork` option, and output redirection.