### PR TITLE
need empty --ethapi for non-geth mode

### DIFF
--- a/contents/runninganode.rst
+++ b/contents/runninganode.rst
@@ -83,6 +83,7 @@ Set up you environment as seen above, ie., make sure you have a data directory.
 
   swarm --bzzaccount $BZZKEY \
          --datadir $DATADIR \
+         --ethapi '' \
          2>> $DATADIR/swarm.log < <(echo -n "MYPASSWORD") &
 
 The ``swarm`` daemon will seek out and connect to other swarm nodes. It manages its own peer connections independent of ``geth``.


### PR DESCRIPTION
this PR fixes an error in the guide.
It is not enough simply to leave off the `--ethapi` string when running in local only mode, you need `--ethapi ''`