### PR TITLE
Updated the version of go

### DIFF
--- a/contents/installation.rst
+++ b/contents/installation.rst
@@ -62,13 +62,14 @@ Download the latest distribution
 
 .. code-block:: none
 
-  curl -O https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz
+  curl -O https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz
 
 Unpack it to the /usr/local (might require sudo)
 
 .. code-block:: none
 
-  tar -C /usr/local -xzf go1.7.3.linux-amd64.tar.gz
+ tar -C /usr/local -xzf go1.8.3.linux-amd64.tar.gz
+
 
 Set GOPATH and PATH
 


### PR DESCRIPTION
The installation steps installed go version 1.6, which was causing `import path does not begin with hostname` error. Updating version to 1.8.3 resolves the issue on the ubuntu machine.