### PR TITLE
Missing trailing slash from bzz url

### DIFF
--- a/contents/simpleuser.rst
+++ b/contents/simpleuser.rst
@@ -76,7 +76,7 @@ To download a file from swarm, you just need the file's address string. Once you
 
 .. code-block:: none
 
-  curl http://localhost:8500/bzz:/027e57bcbae76c4b6a1c5ce589be41232498f1af86e1b1a2fc2bdffd740e9b39
+  curl http://localhost:8500/bzz:/027e57bcbae76c4b6a1c5ce589be41232498f1af86e1b1a2fc2bdffd740e9b39/
 
 The result should be your file:
 

--- a/contents/simpleuser.rst
+++ b/contents/simpleuser.rst
@@ -84,7 +84,7 @@ The result should be your file:
 
   some-data
 
-And that's it.
+And that's it. Note that if you omit the trailing slash from the url then the request will result in a redirect.
 
 Tar stream upload
 -----------------


### PR DESCRIPTION
This results in a redirect, which curl does not follow by default:
```
$ curl -H "Content-Type: text/plain" --data-binary "some-data" http://0.0.0.0:8502/bzz:/
26469c7f3a1e110d64a84b54b3da3659a4237b3288dc2f5241fa7a3785960d45%
$ curl http://0.0.0.0:8502/bzz:/26469c7f3a1e110d64a84b54b3da3659a4237b3288dc2f5241fa7a3785960d45
<a href="/bzz:/26469c7f3a1e110d64a84b54b3da3659a4237b3288dc2f5241fa7a3785960d45/">Moved Permanently</a>.
```

So let's include the trailing slash in the example, and then it works:
```
$ curl http://0.0.0.0:8502/bzz:/26469c7f3a1e110d64a84b54b3da3659a4237b3288dc2f5241fa7a3785960d45/
some-data%
```