### PR TITLE
Use Docker to simplify local build setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.7.1
+
+RUN pip install \
+    Sphinx==1.8.2 \
+    sphinx-rtd-theme==0.4.2
+
+RUN mkdir -p /src
+WORKDIR /src
+

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
+html-docker:
+	@which docker &> /dev/null || (echo "please, install Docker to use this target" >&2 && exit 1)
+	@docker build --tag swarm-sphinx .
+	@docker run --rm --volume $$PWD:/src swarm-sphinx make html
+
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-# swarm-guide
+# Swarm Guide
 
-swarm documentation in sphinx, hosted on read the docs: http://swarm-guide.readthedocs.io
+Swarm's documentation in sphinx, hosted on read the docs:
+http://swarm-guide.readthedocs.io
 
-## to set up the environment (mac)
-```shell
-brew install sphinx-doc
-pip install sphinx_rtd_theme
-cd swarm-guide
-mkdir -p docs/_themes
-cd docs/_themes
-ln -s /usr/local/lib/python2.7/site-packages/sphinx_rtd_theme sphinx_rtd_theme
-sed -i -e 's/^#html_theme_path*/html_theme_path/g' contents/conf.py # don't push
-```
+## Building the source
 
-To compile the html,
+After building the source you will find `index.html` in `./build/html/` folder.
 
-```shell
-cd swarm-guide
-make html
-```
+### Requirements
 
+- GNU Make
+- Docker or Python (pip)
+
+### Using Docker
+
+After you have `docker` available just call `make html-docker`.
+
+### Native with Python
+
+Call `sudo pip install Sphinx sphinx-rtd-theme` then call `make html`.

--- a/contents/conf.py
+++ b/contents/conf.py
@@ -130,7 +130,7 @@ html_theme_options = {
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = ["../docs/_themes/" ]
+# html_theme_path = ["../docs/_themes/" ]
 
 
 # The name for this set of Sphinx documents.  If None, it defaults to


### PR DESCRIPTION
Note: contents/conf.py is changed because uncommenting `html_theme_path`
was committed in 0ff3cb56e8b8c27d61b229073712832ac9fcdd1b, but according
to the old README.md that should not happen.